### PR TITLE
Add date, time, and datetime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Types:
 - `string`
 - `atom`
 - `date` (ISO 8601)
+- `time` (ISO 8601)
 - `datetime` (ISO 8601)
 - `map`
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Types:
 - `float`
 - `string`
 - `atom`
+- `date` (ISO 8601)
 - `datetime` (ISO 8601)
 - `map`
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ attribute :low_power_mode, :boolean, optional: true
 attribute :dns_servers,    [:string]
 
 attribute :metadata do
-  attribute :location,   :string
-  attribute :department, :string
+  attribute :location,        :string
+  attribute :department,      :string
+  attribute :commissioned_at, :datetime
 
   attribute :ports do
     attribute :rs485, :integer
@@ -133,6 +134,7 @@ Types:
 - `float`
 - `string`
 - `atom`
+- `datetime` (ISO 8601)
 - `map`
 
 Lists:

--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -162,6 +162,18 @@ defmodule Speck do
   defp do_validate(:atom, value, _opts) when is_binary(value), do: String.to_atom(value)
   defp do_validate(:atom, value, _opts) when is_atom(value), do: value
 
+  defp do_validate(:date, value, _opts) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date}               -> date
+      {:error, :invalid_format} -> {:error, :wrong_format}
+      error                     -> error
+    end
+  end
+
+  defp do_validate(:date, %Date{} = value, _opts) do
+    value
+  end
+
   defp do_validate(:datetime, value, _opts) when is_binary(value) do
     case DateTime.from_iso8601(value) do
       {:ok, datetime, _offset} ->
@@ -205,12 +217,14 @@ defmodule Speck do
         _ when is_float(value)   -> value
         _ when is_integer(value) -> value
         _ when is_binary(value)  -> String.length(value)
+        %Date{}                  -> value
         %DateTime{}              -> value
         %NaiveDateTime{}         -> value
       end
 
     error? =
       case v do
+        %Date{}          -> Date.compare(v, limit) == :lt
         %DateTime{}      -> DateTime.compare(v, limit) == :lt
         %NaiveDateTime{} -> NaiveDateTime.compare(v, limit) == :lt
         _                -> v < limit
@@ -231,12 +245,14 @@ defmodule Speck do
         _ when is_float(value)   -> value
         _ when is_integer(value) -> value
         _ when is_binary(value)  -> String.length(value)
+        %Date{}                  -> value
         %DateTime{}              -> value
         %NaiveDateTime{}         -> value
       end
 
     error? =
       case v do
+        %Date{}          -> Date.compare(v, limit) == :gt
         %DateTime{}      -> DateTime.compare(v, limit) == :gt
         %NaiveDateTime{} -> NaiveDateTime.compare(v, limit) == :gt
         _                -> v > limit

--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -174,6 +174,18 @@ defmodule Speck do
     value
   end
 
+  defp do_validate(:time, value, _opts) when is_binary(value) do
+    case Time.from_iso8601(value) do
+      {:ok, time}               -> time
+      {:error, :invalid_format} -> {:error, :wrong_format}
+      error                     -> error
+    end
+  end
+
+  defp do_validate(:time, %Time{} = value, _opts) do
+    value
+  end
+
   defp do_validate(:datetime, value, _opts) when is_binary(value) do
     case DateTime.from_iso8601(value) do
       {:ok, datetime, _offset} ->
@@ -218,6 +230,7 @@ defmodule Speck do
         _ when is_integer(value) -> value
         _ when is_binary(value)  -> String.length(value)
         %Date{}                  -> value
+        %Time{}                  -> value
         %DateTime{}              -> value
         %NaiveDateTime{}         -> value
       end
@@ -225,6 +238,7 @@ defmodule Speck do
     error? =
       case v do
         %Date{}          -> Date.compare(v, limit) == :lt
+        %Time{}          -> Time.compare(v, limit) == :lt
         %DateTime{}      -> DateTime.compare(v, limit) == :lt
         %NaiveDateTime{} -> NaiveDateTime.compare(v, limit) == :lt
         _                -> v < limit
@@ -246,6 +260,7 @@ defmodule Speck do
         _ when is_integer(value) -> value
         _ when is_binary(value)  -> String.length(value)
         %Date{}                  -> value
+        %Time{}                  -> value
         %DateTime{}              -> value
         %NaiveDateTime{}         -> value
       end
@@ -253,6 +268,7 @@ defmodule Speck do
     error? =
       case v do
         %Date{}          -> Date.compare(v, limit) == :gt
+        %Time{}          -> Time.compare(v, limit) == :gt
         %DateTime{}      -> DateTime.compare(v, limit) == :gt
         %NaiveDateTime{} -> NaiveDateTime.compare(v, limit) == :gt
         _                -> v > limit

--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -162,17 +162,61 @@ defmodule Speck do
   defp do_validate(:atom, value, _opts) when is_binary(value), do: String.to_atom(value)
   defp do_validate(:atom, value, _opts) when is_atom(value), do: value
 
+  defp do_validate(:datetime, value, _opts) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} ->
+        datetime
+
+      {:error, :missing_offset} ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, datetime}           -> datetime
+          {:error, :invalid_format} -> {:error, :wrong_format}
+          error                     -> error
+        end
+
+      {:error, :invalid_format} ->
+        {:error, :wrong_format}
+
+      error ->
+        error
+    end
+  end
+
+  defp do_validate(:datetime, value, _opts) when is_integer(value) do
+    case DateTime.from_unix(value) do
+      {:ok, datetime} -> datetime
+      error           -> error
+    end
+  end
+
+  defp do_validate(:datetime, %DateTime{} = value, _opts) do
+    value
+  end
+
+  defp do_validate(:datetime, %NaiveDateTime{} = value, _opts) do
+    value
+  end
+
   defp do_validate(_type, _value, _opts), do: {:error, :wrong_type}
 
   defp apply_min({value, nil = _error}, limit) when not is_nil(limit) do
     v =
-      cond do
-        is_float(value)   -> value
-        is_integer(value) -> value
-        is_binary(value)  -> String.length(value)
+      case value do
+        _ when is_float(value)   -> value
+        _ when is_integer(value) -> value
+        _ when is_binary(value)  -> String.length(value)
+        %DateTime{}              -> value
+        %NaiveDateTime{}         -> value
       end
 
-    error = if v >= limit, do: nil, else: :less_than_min
+    error? =
+      case v do
+        %DateTime{}      -> DateTime.compare(v, limit) == :lt
+        %NaiveDateTime{} -> NaiveDateTime.compare(v, limit) == :lt
+        _                -> v < limit
+      end
+
+    error = if error?, do: :less_than_min, else: nil
 
     {value, error}
   end
@@ -183,13 +227,22 @@ defmodule Speck do
 
   defp apply_max({value, nil = _error}, limit) when not is_nil(limit) do
     v =
-      cond do
-        is_float(value)   -> value
-        is_integer(value) -> value
-        is_binary(value)  -> String.length(value)
+      case value do
+        _ when is_float(value)   -> value
+        _ when is_integer(value) -> value
+        _ when is_binary(value)  -> String.length(value)
+        %DateTime{}              -> value
+        %NaiveDateTime{}         -> value
       end
 
-    error = if v <= limit, do: nil, else: :greater_than_max
+    error? =
+      case v do
+        %DateTime{}      -> DateTime.compare(v, limit) == :gt
+        %NaiveDateTime{} -> NaiveDateTime.compare(v, limit) == :gt
+        _                -> v > limit
+      end
+
+    error = if error?, do: :greater_than_max, else: nil
 
     {value, error}
   end

--- a/protocol/mqtt/add_device.v1.ex
+++ b/protocol/mqtt/add_device.v1.ex
@@ -11,8 +11,9 @@ attribute :low_power_mode, :boolean, optional: true
 attribute :dns_servers,    [:string]
 
 attribute :metadata do
-  attribute :location,   :string
-  attribute :department, :string
+  attribute :location,        :string
+  attribute :department,      :string
+  attribute :commissioned_at, :datetime
 
   attribute :ports do
     attribute :rs485, :integer

--- a/protocol/test/date.ex
+++ b/protocol/test/date.ex
@@ -1,0 +1,5 @@
+struct TestSchema.Date
+
+name "date"
+
+attribute :param1, :date

--- a/protocol/test/datetime.ex
+++ b/protocol/test/datetime.ex
@@ -1,0 +1,5 @@
+struct TestSchema.DateTime
+
+name "datetime"
+
+attribute :param1, :datetime

--- a/protocol/test/default.ex
+++ b/protocol/test/default.ex
@@ -2,8 +2,9 @@ struct TestSchema.Default
 
 name "default"
 
-attribute :param1, :integer, default: 2
-attribute :param2, :float,   default: 2.4
-attribute :param3, :string,  default: "foo"
-attribute :param4, :atom,    default: :foo
-attribute :param5, :boolean, default: true
+attribute :param1, :integer,  default: 2
+attribute :param2, :float,    default: 2.4
+attribute :param3, :string,   default: "foo"
+attribute :param4, :atom,     default: :foo
+attribute :param5, :boolean,  default: true
+attribute :param6, :datetime, default: ~U[2023-05-15 01:02:03Z]

--- a/protocol/test/default.ex
+++ b/protocol/test/default.ex
@@ -8,3 +8,4 @@ attribute :param3, :string,   default: "foo"
 attribute :param4, :atom,     default: :foo
 attribute :param5, :boolean,  default: true
 attribute :param6, :datetime, default: ~U[2023-05-15 01:02:03Z]
+attribute :param7, :date,     default: ~D[2023-05-15]

--- a/protocol/test/default.ex
+++ b/protocol/test/default.ex
@@ -9,3 +9,4 @@ attribute :param4, :atom,     default: :foo
 attribute :param5, :boolean,  default: true
 attribute :param6, :datetime, default: ~U[2023-05-15 01:02:03Z]
 attribute :param7, :date,     default: ~D[2023-05-15]
+attribute :param8, :time,     default: ~T[01:02:03]

--- a/protocol/test/falsy_values.ex
+++ b/protocol/test/falsy_values.ex
@@ -6,3 +6,4 @@ attribute :param1, :boolean
 attribute :param2, :string
 attribute :param3, :integer
 attribute :param4, [:boolean]
+attribute :param5, :datetime

--- a/protocol/test/min_max.ex
+++ b/protocol/test/min_max.ex
@@ -6,3 +6,4 @@ attribute :param_integer,  :integer,  min: 1,                     max: 10
 attribute :param_float,    :float,    min: 1.4,                   max: 9.7
 attribute :param_string,   :string,   min: 2,                     max: 8
 attribute :param_datetime, :datetime, min: "2020-01-01 00:00:00", max: "2030-01-01 00:00:00"
+attribute :param_date,     :date,     min: "2020-01-01",          max: "2030-01-01"

--- a/protocol/test/min_max.ex
+++ b/protocol/test/min_max.ex
@@ -2,6 +2,7 @@ struct TestSchema.MinMax
 
 name "min_max"
 
-attribute :param_integer, :integer, min: 1,   max: 10
-attribute :param_float,   :float,   min: 1.4, max: 9.7
-attribute :param_string,  :string,  min: 2,   max: 8
+attribute :param_integer,  :integer,  min: 1,                     max: 10
+attribute :param_float,    :float,    min: 1.4,                   max: 9.7
+attribute :param_string,   :string,   min: 2,                     max: 8
+attribute :param_datetime, :datetime, min: "2020-01-01 00:00:00", max: "2030-01-01 00:00:00"

--- a/protocol/test/min_max.ex
+++ b/protocol/test/min_max.ex
@@ -7,3 +7,4 @@ attribute :param_float,    :float,    min: 1.4,                   max: 9.7
 attribute :param_string,   :string,   min: 2,                     max: 8
 attribute :param_datetime, :datetime, min: "2020-01-01 00:00:00", max: "2030-01-01 00:00:00"
 attribute :param_date,     :date,     min: "2020-01-01",          max: "2030-01-01"
+attribute :param_time,     :time,     min: "05:00:00",            max: "14:00:00"

--- a/protocol/test/not_present.ex
+++ b/protocol/test/not_present.ex
@@ -7,3 +7,4 @@ attribute :param2, :float
 attribute :param3, :string
 attribute :param4, :atom
 attribute :param5, :boolean
+attribute :param6, :datetime

--- a/protocol/test/not_present.ex
+++ b/protocol/test/not_present.ex
@@ -9,3 +9,4 @@ attribute :param4, :atom
 attribute :param5, :boolean
 attribute :param6, :datetime
 attribute :param7, :date
+attribute :param8, :time

--- a/protocol/test/not_present.ex
+++ b/protocol/test/not_present.ex
@@ -8,3 +8,4 @@ attribute :param3, :string
 attribute :param4, :atom
 attribute :param5, :boolean
 attribute :param6, :datetime
+attribute :param7, :date

--- a/protocol/test/time.ex
+++ b/protocol/test/time.ex
@@ -1,0 +1,5 @@
+struct TestSchema.Time
+
+name "time"
+
+attribute :param1, :time

--- a/protocol/test/wrong_type.ex
+++ b/protocol/test/wrong_type.ex
@@ -5,3 +5,4 @@ name "wrong_type"
 attribute :param1, :integer
 attribute :param2, :float
 attribute :param3, :boolean
+attribute :param4, :datetime

--- a/protocol/test/wrong_type.ex
+++ b/protocol/test/wrong_type.ex
@@ -6,3 +6,4 @@ attribute :param1, :integer
 attribute :param2, :float
 attribute :param3, :boolean
 attribute :param4, :datetime
+attribute :param5, :date

--- a/protocol/test/wrong_type.ex
+++ b/protocol/test/wrong_type.ex
@@ -7,3 +7,4 @@ attribute :param2, :float
 attribute :param3, :boolean
 attribute :param4, :datetime
 attribute :param5, :date
+attribute :param6, :time

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -13,9 +13,10 @@ defmodule Speck.Test do
         "1.0.0.1",
       ],
       "metadata" => %{
-        "location"   => "Warehouse 1",
-        "department" => "Logistics",
-        "ports"      => %{
+        "location"        => "Warehouse 1",
+        "department"      => "Logistics",
+        "commissioned_at" => "2023-05-15 18:15:04Z",
+        "ports"           => %{
           "rs485" => 4
         }
       },
@@ -38,9 +39,10 @@ defmodule Speck.Test do
           "1.0.0.1",
         ],
         metadata: %{
-          location:   "Warehouse 1",
-          department: "Logistics",
-          ports:      %{
+          location:        "Warehouse 1",
+          department:      "Logistics",
+          commissioned_at: ~U[2023-05-15 18:15:04Z],
+          ports:           %{
             rs485: 4
           }
         },
@@ -61,6 +63,7 @@ defmodule Speck.Test do
         param3: "foo",
         param4: :foo,
         param5: true,
+        param6: ~U[2023-05-15 01:02:03Z],
       }}
   end
 
@@ -75,8 +78,9 @@ defmodule Speck.Test do
         serial_number: :not_present,
         dns_servers:   :not_present,
         metadata: %{
-          location:   :not_present,
-          department: :not_present,
+          location:        :not_present,
+          department:      :not_present,
+          commissioned_at: :not_present,
           ports: %{
             rs485: :not_present,
           }
@@ -89,6 +93,7 @@ defmodule Speck.Test do
       "param1" => "invalid",
       "param2" => "invalid",
       "param3" => "invalid",
+      "param4" => 2.7,
     }
 
     assert Speck.validate(TestSchema.WrongType, params) ==
@@ -96,6 +101,7 @@ defmodule Speck.Test do
         param1: :wrong_type,
         param2: :wrong_type,
         param3: :wrong_type,
+        param4: :wrong_type,
       }}
   end
 
@@ -176,6 +182,7 @@ defmodule Speck.Test do
         param3: :not_present,
         param4: :not_present,
         param5: :not_present,
+        param6: :not_present,
       }}
   end
 
@@ -185,6 +192,7 @@ defmodule Speck.Test do
       "param2" => "",
       "param3" => 0,
       "param4" => [false, false, false],
+      "param5" => 0,
     }
 
     assert Speck.validate(TestSchema.FalsyValues, params) ==
@@ -193,37 +201,117 @@ defmodule Speck.Test do
         param2: "",
         param3: 0,
         param4: [false, false, false],
+        param5: ~U[1970-01-01 00:00:00Z],
       }}
+  end
+
+  describe "datetime" do
+    test "can parse ISO 8601 with zulu (UTC) offset" do
+      params = %{
+        "param1" => "2023-05-15 01:02:03Z"
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:ok, %TestSchema.DateTime{
+          param1: ~U[2023-05-15 01:02:03Z]
+        }}
+    end
+
+    test "can parse ISO 8601 with offset" do
+      params = %{
+        "param1" => "2023-05-15 11:15:04-07"
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:ok, %TestSchema.DateTime{
+          param1: ~U[2023-05-15 18:15:04Z]
+        }}
+    end
+
+    test "can parse ISO 8601 without offset" do
+      params = %{
+        "param1" => "2023-05-15 01:02:03"
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:ok, %TestSchema.DateTime{
+          param1: ~N[2023-05-15 01:02:03]
+        }}
+    end
+
+    test "can parse unix timestamp in seconds" do
+      params = %{
+        "param1" => 1684112523
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:ok, %TestSchema.DateTime{
+          param1: ~U[2023-05-15 01:02:03Z]
+        }}
+    end
+
+    test "passes through DateTime and NaiveDateTime structs" do
+      params = %{
+        "param1" => ~U[2023-05-15 01:02:03Z]
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:ok, %TestSchema.DateTime{
+          param1: ~U[2023-05-15 01:02:03Z]
+        }}
+
+      params = %{
+        "param1" => ~N[2023-05-15 01:02:03]
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:ok, %TestSchema.DateTime{
+          param1: ~N[2023-05-15 01:02:03]
+        }}
+    end
+
+    test "returns an error if the value can't be parsed" do
+      params = %{
+        "param1" => "invalid"
+      }
+
+      assert Speck.validate(TestSchema.DateTime, params) ==
+        {:error, %{param1: :wrong_format}}
+    end
   end
 
   describe "min limit" do
     test "coerces params that meet the min limit" do
       params = %{
-        "param_integer" => 1,
-        "param_float"   => 1.4,
-        "param_string"  => "ab",
+        "param_integer"  => 1,
+        "param_float"    => 1.4,
+        "param_string"   => "ab",
+        "param_datetime" => "2023-05-15 00:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
         {:ok, %TestSchema.MinMax{
-          param_integer: 1,
-          param_float:   1.4,
-          param_string:  "ab",
+          param_integer:  1,
+          param_float:    1.4,
+          param_string:   "ab",
+          param_datetime: ~N[2023-05-15 00:00:00],
         }}
     end
 
     test "returns error if less than min limit" do
       params = %{
-        "param_integer" => 0,
-        "param_float"   => -1.6,
-        "param_string"  => "a",
+        "param_integer"  => 0,
+        "param_float"    => -1.6,
+        "param_string"   => "a",
+        "param_datetime" => "1970-01-01 00:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
         {:error, %{
-          param_integer: :less_than_min,
-          param_float:   :less_than_min,
-          param_string:  :less_than_min,
+          param_integer:  :less_than_min,
+          param_float:    :less_than_min,
+          param_string:   :less_than_min,
+          param_datetime: :less_than_min,
         }}
     end
   end
@@ -231,31 +319,35 @@ defmodule Speck.Test do
   describe "max limit" do
     test "coerces params that meet the max limit" do
       params = %{
-        "param_integer" => 10,
-        "param_float"   => 9.7,
-        "param_string"  => "abcdefgh",
+        "param_integer"  => 10,
+        "param_float"    => 9.7,
+        "param_string"   => "abcdefgh",
+        "param_datetime" => "2023-05-15 00:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
         {:ok, %TestSchema.MinMax{
-          param_integer: 10,
-          param_float:   9.7,
-          param_string:  "abcdefgh",
+          param_integer:  10,
+          param_float:    9.7,
+          param_string:   "abcdefgh",
+          param_datetime: ~N[2023-05-15 00:00:00],
         }}
     end
 
     test "returns error if greater than max limit" do
       params = %{
-        "param_integer" => 11,
-        "param_float"   => 15.3,
-        "param_string"  => "ABCDEFGHIJK",
+        "param_integer"  => 11,
+        "param_float"    => 15.3,
+        "param_string"   => "ABCDEFGHIJK",
+        "param_datetime" => "2050-01-01 00:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
         {:error, %{
-          param_integer: :greater_than_max,
-          param_float:   :greater_than_max,
-          param_string:  :greater_than_max,
+          param_integer:  :greater_than_max,
+          param_float:    :greater_than_max,
+          param_string:   :greater_than_max,
+          param_datetime: :greater_than_max,
         }}
     end
   end

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -64,6 +64,7 @@ defmodule Speck.Test do
         param4: :foo,
         param5: true,
         param6: ~U[2023-05-15 01:02:03Z],
+        param7: ~D[2023-05-15],
       }}
   end
 
@@ -94,6 +95,7 @@ defmodule Speck.Test do
       "param2" => "invalid",
       "param3" => "invalid",
       "param4" => 2.7,
+      "param5" => 2.7,
     }
 
     assert Speck.validate(TestSchema.WrongType, params) ==
@@ -102,6 +104,7 @@ defmodule Speck.Test do
         param2: :wrong_type,
         param3: :wrong_type,
         param4: :wrong_type,
+        param5: :wrong_type,
       }}
   end
 
@@ -183,6 +186,7 @@ defmodule Speck.Test do
         param4: :not_present,
         param5: :not_present,
         param6: :not_present,
+        param7: :not_present,
       }}
   end
 
@@ -280,6 +284,39 @@ defmodule Speck.Test do
     end
   end
 
+  describe "date" do
+    test "can parse ISO 8601" do
+      params = %{
+        "param1" => "2023-05-15"
+      }
+
+      assert Speck.validate(TestSchema.Date, params) ==
+        {:ok, %TestSchema.Date{
+          param1: ~D[2023-05-15]
+        }}
+    end
+
+    test "passes through Date struct" do
+      params = %{
+        "param1" => ~D[2023-05-15]
+      }
+
+      assert Speck.validate(TestSchema.Date, params) ==
+        {:ok, %TestSchema.Date{
+          param1: ~D[2023-05-15]
+        }}
+    end
+
+    test "returns an error if the value can't be parsed" do
+      params = %{
+        "param1" => "invalid"
+      }
+
+      assert Speck.validate(TestSchema.Date, params) ==
+        {:error, %{param1: :wrong_format}}
+    end
+  end
+
   describe "min limit" do
     test "coerces params that meet the min limit" do
       params = %{
@@ -287,6 +324,7 @@ defmodule Speck.Test do
         "param_float"    => 1.4,
         "param_string"   => "ab",
         "param_datetime" => "2023-05-15 00:00:00",
+        "param_date"     => "2023-05-15",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -295,6 +333,7 @@ defmodule Speck.Test do
           param_float:    1.4,
           param_string:   "ab",
           param_datetime: ~N[2023-05-15 00:00:00],
+          param_date:     ~D[2023-05-15],
         }}
     end
 
@@ -304,6 +343,7 @@ defmodule Speck.Test do
         "param_float"    => -1.6,
         "param_string"   => "a",
         "param_datetime" => "1970-01-01 00:00:00",
+        "param_date"     => "1970-01-01",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -312,6 +352,7 @@ defmodule Speck.Test do
           param_float:    :less_than_min,
           param_string:   :less_than_min,
           param_datetime: :less_than_min,
+          param_date:     :less_than_min,
         }}
     end
   end
@@ -323,6 +364,7 @@ defmodule Speck.Test do
         "param_float"    => 9.7,
         "param_string"   => "abcdefgh",
         "param_datetime" => "2023-05-15 00:00:00",
+        "param_date"     => "2023-05-15",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -331,6 +373,7 @@ defmodule Speck.Test do
           param_float:    9.7,
           param_string:   "abcdefgh",
           param_datetime: ~N[2023-05-15 00:00:00],
+          param_date:     ~D[2023-05-15],
         }}
     end
 
@@ -340,6 +383,7 @@ defmodule Speck.Test do
         "param_float"    => 15.3,
         "param_string"   => "ABCDEFGHIJK",
         "param_datetime" => "2050-01-01 00:00:00",
+        "param_date"     => "2050-01-01",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -348,6 +392,7 @@ defmodule Speck.Test do
           param_float:    :greater_than_max,
           param_string:   :greater_than_max,
           param_datetime: :greater_than_max,
+          param_date:     :greater_than_max,
         }}
     end
   end

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -65,6 +65,7 @@ defmodule Speck.Test do
         param5: true,
         param6: ~U[2023-05-15 01:02:03Z],
         param7: ~D[2023-05-15],
+        param8: ~T[01:02:03],
       }}
   end
 
@@ -96,6 +97,7 @@ defmodule Speck.Test do
       "param3" => "invalid",
       "param4" => 2.7,
       "param5" => 2.7,
+      "param6" => 2.7,
     }
 
     assert Speck.validate(TestSchema.WrongType, params) ==
@@ -105,6 +107,7 @@ defmodule Speck.Test do
         param3: :wrong_type,
         param4: :wrong_type,
         param5: :wrong_type,
+        param6: :wrong_type,
       }}
   end
 
@@ -187,6 +190,7 @@ defmodule Speck.Test do
         param5: :not_present,
         param6: :not_present,
         param7: :not_present,
+        param8: :not_present,
       }}
   end
 
@@ -317,6 +321,39 @@ defmodule Speck.Test do
     end
   end
 
+  describe "time" do
+    test "can parse ISO 8601" do
+      params = %{
+        "param1" => "01:02:03"
+      }
+
+      assert Speck.validate(TestSchema.Time, params) ==
+        {:ok, %TestSchema.Time{
+          param1: ~T[01:02:03]
+        }}
+    end
+
+    test "passes through Time struct" do
+      params = %{
+        "param1" => ~T[01:02:03]
+      }
+
+      assert Speck.validate(TestSchema.Time, params) ==
+        {:ok, %TestSchema.Time{
+          param1: ~T[01:02:03]
+        }}
+    end
+
+    test "returns an error if the value can't be parsed" do
+      params = %{
+        "param1" => "invalid"
+      }
+
+      assert Speck.validate(TestSchema.Time, params) ==
+        {:error, %{param1: :wrong_format}}
+    end
+  end
+
   describe "min limit" do
     test "coerces params that meet the min limit" do
       params = %{
@@ -325,6 +362,7 @@ defmodule Speck.Test do
         "param_string"   => "ab",
         "param_datetime" => "2023-05-15 00:00:00",
         "param_date"     => "2023-05-15",
+        "param_time"     => "11:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -334,6 +372,7 @@ defmodule Speck.Test do
           param_string:   "ab",
           param_datetime: ~N[2023-05-15 00:00:00],
           param_date:     ~D[2023-05-15],
+          param_time:     ~T[11:00:00],
         }}
     end
 
@@ -344,6 +383,7 @@ defmodule Speck.Test do
         "param_string"   => "a",
         "param_datetime" => "1970-01-01 00:00:00",
         "param_date"     => "1970-01-01",
+        "param_time"     => "01:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -353,6 +393,7 @@ defmodule Speck.Test do
           param_string:   :less_than_min,
           param_datetime: :less_than_min,
           param_date:     :less_than_min,
+          param_time:     :less_than_min,
         }}
     end
   end
@@ -365,6 +406,7 @@ defmodule Speck.Test do
         "param_string"   => "abcdefgh",
         "param_datetime" => "2023-05-15 00:00:00",
         "param_date"     => "2023-05-15",
+        "param_time"     => "11:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -374,6 +416,7 @@ defmodule Speck.Test do
           param_string:   "abcdefgh",
           param_datetime: ~N[2023-05-15 00:00:00],
           param_date:     ~D[2023-05-15],
+          param_time:     ~T[11:00:00],
         }}
     end
 
@@ -384,6 +427,7 @@ defmodule Speck.Test do
         "param_string"   => "ABCDEFGHIJK",
         "param_datetime" => "2050-01-01 00:00:00",
         "param_date"     => "2050-01-01",
+        "param_time"     => "18:00:00",
       }
 
       assert Speck.validate(TestSchema.MinMax, params) ==
@@ -393,6 +437,7 @@ defmodule Speck.Test do
           param_string:   :greater_than_max,
           param_datetime: :greater_than_max,
           param_date:     :greater_than_max,
+          param_time:     :greater_than_max,
         }}
     end
   end


### PR DESCRIPTION
This PR implements validation and coercion for dates, times, and datetimes. They can be passed as ISO 8601 strings, or as Elixir's native types.