### PR TITLE
Defer map/list initialization to the next merge handler

### DIFF
--- a/lib/speck/validation_metadata/attribute.ex
+++ b/lib/speck/validation_metadata/attribute.ex
@@ -43,7 +43,7 @@ defmodule Speck.ValidationMetadata.Attribute do
 
   defp merge(nil = _params, [attribute | path], value, strategy)
     when not is_integer(attribute) do
-      %{attribute => merge(%{}, path, value, strategy)}
+      %{attribute => merge(nil, path, value, strategy)}
   end
 
   defp merge(params, [path], value, strategy) when is_map(params) do

--- a/test/validation_metadata/attribute_test.exs
+++ b/test/validation_metadata/attribute_test.exs
@@ -12,6 +12,26 @@ defmodule Speck.ValidationMetadata.Attribute.Test do
       %{"state" => %{"reported" => %{"serial" => "sn1234"}}}
   end
 
+  test "merge nested lists" do
+    attributes = [
+      {["state", "reported", "a", 0, "b", 0, "c", 0, "d", 0, "id"], :unknown, 1001},
+      {["state", "reported", "a", 1, "b", 0, "c", 0, "d", 0, "id"], :unknown, 1002},
+    ]
+
+    params = %{state: %{reported: %{}}}
+
+    assert Attribute.merge(attributes, params) == %{
+      "state" => %{
+        "reported" => %{
+          "a" => [
+            %{"b" => [%{"c" => [%{"d" => [%{"id" => 1001}]}]}]},
+            %{"b" => [%{"c" => [%{"d" => [%{"id" => 1002}]}]}]},
+          ]
+        }
+      }
+    }
+  end
+
   describe "merge strategy" do
     test "attribute priority" do
       params = %{"name" => "Test Device"}


### PR DESCRIPTION
This PR fixes an issue in `Attribute.merge` where it was assumed if a param from the original payload didn't exist, it should be initialized with an empty map (`%{}`). However, this didn't account for when an empty list (`[]`) should be initialized instead. This would be the case if the next path element is an integer.

This PR removes the early initialization of the missing parameter, and defers it to the next `merge` handler that should be called based on the next part of the path.

This bug would raise the following error:

```
  1) test merge nested lists (Speck.ValidationMetadata.Attribute.Test)
     test/validation_metadata/attribute_test.exs:15
     ** (FunctionClauseError) no function clause matching in List.insert_at/3

     The following arguments were given to List.insert_at/3:

         # 1
         %{}

         # 2
         -1

         # 3
         %{"id" => 1001}

     Attempted function clauses (showing 1 out of 1):

         def insert_at(list, index, value) when is_list(list) and is_integer(index)

     code: assert Attribute.merge(attributes, params) == %{
     stacktrace:
       (elixir 1.18.3) lib/list.ex:776: List.insert_at/3
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:46: Speck.ValidationMetadata.Attribute.merge/4
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:65: Speck.ValidationMetadata.Attribute.merge/4
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:46: Speck.ValidationMetadata.Attribute.merge/4
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:65: Speck.ValidationMetadata.Attribute.merge/4
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:46: Speck.ValidationMetadata.Attribute.merge/4
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:65: Speck.ValidationMetadata.Attribute.merge/4
       (speck 4.0.0) lib/speck/validation_metadata/attribute.ex:75: Speck.ValidationMetadata.Attribute.merge/4
       (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
       test/validation_metadata/attribute_test.exs:23: (test)
```